### PR TITLE
Remove undefined variable

### DIFF
--- a/polyfit/polyfit.py
+++ b/polyfit/polyfit.py
@@ -271,7 +271,7 @@ class PolynomRegressor(BaseEstimator, RegressorMixin):
                 strict_curvature = Feature_constraints.curvature is not None
                 
 
-                if monotonic or strict_curvature or ybound:
+                if monotonic or strict_curvature:
 
                     if Feature_constraints.constraint_range is None:
 


### PR DESCRIPTION
There was a typo to an undefined variable `ybounds` that is only triggered when an empty `Constraints` object is passed to `PolynomRegressor.fit`, so I removed it.  In this case the optimization also seems to be taking very long, so probably it's not a good idea in the first place, but simply something I found testing things out.